### PR TITLE
Feature/django2x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7"
 env:
   - DB=sqlite3 DJANGO=1.7
   - DB=mysql DJANGO=1.7
@@ -22,8 +24,24 @@ env:
   - DB=sqlite3 DJANGO=1.11
   - DB=mysql DJANGO=1.11
   - DB=postgres DJANGO=1.11
+  - DB=mysql DJANGO=2.0
+  - DB=postgres DJANGO=2.0
+  - DB=mysql DJANGO=2.2
+  - DB=postgres DJANGO=2.2
 matrix:
   exclude:
+    - python: "3.7"
+      env: DB=sqlite3 DJANGO=1.7
+    - python: "3.7"
+      env: DB=mysql DJANGO=1.7
+    - python: "3.7"
+      env: DB=postgres DJANGO=1.7
+    - python: "3.6"
+      env: DB=sqlite3 DJANGO=1.7
+    - python: "3.6"
+      env: DB=mysql DJANGO=1.7
+    - python: "3.6"
+      env: DB=postgres DJANGO=1.7
     - python: "3.5"
       env: DB=sqlite3 DJANGO=1.7
     - python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: trusty
 sudo: required
 language: python
 python:
@@ -6,8 +6,6 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
-  - "3.6"
-  - "3.7"
 env:
   - DB=sqlite3 DJANGO=1.7
   - DB=mysql DJANGO=1.7
@@ -30,18 +28,6 @@ env:
   - DB=postgres DJANGO=2.2
 matrix:
   exclude:
-    - python: "3.7"
-      env: DB=sqlite3 DJANGO=1.7
-    - python: "3.7"
-      env: DB=mysql DJANGO=1.7
-    - python: "3.7"
-      env: DB=postgres DJANGO=1.7
-    - python: "3.6"
-      env: DB=sqlite3 DJANGO=1.7
-    - python: "3.6"
-      env: DB=mysql DJANGO=1.7
-    - python: "3.6"
-      env: DB=postgres DJANGO=1.7
     - python: "3.5"
       env: DB=sqlite3 DJANGO=1.7
     - python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,18 @@ matrix:
       env: DB=postgres DJANGO=1.11
     - python: "3.3"
       env: DB=mysql DJANGO=1.11
+    - python: "2.7"
+      env: DB=sqlite3 DJANGO=2.0
+    - python: "2.7"
+      env: DB=mysql DJANGO=2.0
+    - python: "2.7"
+      env: DB=postgres DJANGO=2.0
+    - python: "2.7"
+      env: DB=sqlite3 DJANGO=2.2
+    - python: "2.7"
+      env: DB=mysql DJANGO=2.2
+    - python: "2.7"
+      env: DB=postgres DJANGO=2.2
 install:
   - pip install . --no-deps
   - pip install --no-deps -r test_project/requirements-$DJANGO.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,18 @@ matrix:
       env: DB=mysql DJANGO=1.7
     - python: "3.5"
       env: DB=postgres DJANGO=1.7
+    - python: "3.4"
+      env: DB=sqlite3 DJANGO=2.0
+    - python: "3.4"
+      env: DB=postgres DJANGO=2.0
+    - python: "3.4"
+      env: DB=mysql DJANGO=2.0
+    - python: "3.4"
+      env: DB=sqlite3 DJANGO=2.2
+    - python: "3.4"
+      env: DB=postgres DJANGO=2.2
+    - python: "3.4"
+      env: DB=mysql DJANGO=2.2
     - python: "3.3"
       env: DB=sqlite3 DJANGO=1.9
     - python: "3.3"
@@ -52,6 +64,18 @@ matrix:
       env: DB=postgres DJANGO=1.11
     - python: "3.3"
       env: DB=mysql DJANGO=1.11
+    - python: "3.3"
+      env: DB=sqlite3 DJANGO=2.0
+    - python: "3.3"
+      env: DB=postgres DJANGO=2.0
+    - python: "3.3"
+      env: DB=mysql DJANGO=2.0
+    - python: "3.3"
+      env: DB=sqlite3 DJANGO=2.2
+    - python: "3.3"
+      env: DB=postgres DJANGO=2.2
+    - python: "3.3"
+      env: DB=mysql DJANGO=2.2
     - python: "2.7"
       env: DB=sqlite3 DJANGO=2.0
     - python: "2.7"

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -12,6 +12,7 @@ This file lists the people whose contributions have made Daguerre possible.
 * Filip Todić
 * Stjepan Zlodi
 * Artem Zyryanov
+* Nikola Tucković
 
 We have tried to include everyone, but if you've made a contribution and are not listed, please open an issue or a pull request with your name.
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -12,7 +12,6 @@ This file lists the people whose contributions have made Daguerre possible.
 * Filip Todić
 * Stjepan Zlodi
 * Artem Zyryanov
-* Nikola Tucković
 
 We have tried to include everyone, but if you've made a contribution and are not listed, please open an issue or a pull request with your name.
 

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Requirements
 
 * Python 2.7+, 3.3+
 * Pillow
-* Django 1.7 – 1.11
+* Django 1.7 – 2.2
 * Six 1.10.0+
 
 Daguerre *may* work with earlier or later versions of these packages, but they are not officially supported.

--- a/daguerre/helpers.py
+++ b/daguerre/helpers.py
@@ -2,11 +2,17 @@ import datetime
 import itertools
 import ssl
 import struct
+import django
 
 from django.conf import settings
 from django.core.files.base import File
 from django.core.files.storage import default_storage
-from django.core.urlresolvers import reverse
+
+if django.VERSION >= (2, 0):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
+
 from django.http import QueryDict
 from django.template import Variable, VariableDoesNotExist, TemplateSyntaxError
 import six
@@ -93,7 +99,7 @@ class AdjustmentHelper(object):
         self._finalized = False
 
         if lookup is None:
-            lookup_func = lambda obj, default=None: obj
+            def lookup_func(obj, default=None): return obj
         else:
             try:
                 lookup_var = Variable("item.{0}".format(lookup))
@@ -332,7 +338,8 @@ class AdjustmentHelper(object):
                     except IOERRORS:
                         info_dict = AdjustmentInfoDict()
                     else:
-                        info_dict = self._adjusted_image_info_dict(adjusted_image)
+                        info_dict = self._adjusted_image_info_dict(
+                            adjusted_image)
                 else:
                     info_dict = self._path_info_dict(path)
                 for item in items:

--- a/daguerre/widgets.py
+++ b/daguerre/widgets.py
@@ -1,5 +1,10 @@
 from django.contrib.admin.widgets import AdminFileWidget
-from django.core.urlresolvers import reverse
+
+if django.VERSION >= (2, 0):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
+
 from django.utils.safestring import mark_safe
 
 

--- a/daguerre/widgets.py
+++ b/daguerre/widgets.py
@@ -1,3 +1,5 @@
+import django
+
 from django.contrib.admin.widgets import AdminFileWidget
 
 if django.VERSION >= (2, 0):

--- a/test_project/requirements-2.0.txt
+++ b/test_project/requirements-2.0.txt
@@ -1,0 +1,3 @@
+Django==2.0
+pytz==2017.2
+-r requirements.txt

--- a/test_project/requirements-2.2.txt
+++ b/test_project/requirements-2.2.txt
@@ -1,3 +1,4 @@
 Django==2.2
 pytz==2017.2
+sqlparse==0.3.0
 -r requirements.txt

--- a/test_project/requirements-2.2.txt
+++ b/test_project/requirements-2.2.txt
@@ -1,0 +1,3 @@
+Django==2.2
+pytz==2017.2
+-r requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,9 @@ envlist =
     py35-django110,
     py27-django111,
     py34-django111,
-    py35-django111
+    py35-django111,
+    py37-django20,
+    py37-django22
 
 [testenv]
 changedir = {toxinidir}/test_project
@@ -117,3 +119,27 @@ basepython=python3.5
 deps =
     --no-deps
     -r{toxinidir}/test_project/requirements-1.11.txt
+
+[testenv:py36-django20]
+basepython=python3.6
+deps =
+    --no-deps
+    -r{toxinidir}/test_project/requirements-2.0.txt
+
+[testenv:py37-django20]
+basepython=python3.7
+deps =
+    --no-deps
+    -r{toxinidir}/test_project/requirements-2.0.txt
+
+[testenv:py36-django22]
+basepython=python3.6
+deps =
+    --no-deps
+    -r{toxinidir}/test_project/requirements-2.2.txt
+
+[testenv:py37-django22]
+basepython=python3.7
+deps =
+    --no-deps
+    -r{toxinidir}/test_project/requirements-2.2.txt


### PR DESCRIPTION
We're porting our own project to Django 2.2 support, while running tests, there were errors with urlresolvers import.

In additon, travis jobs are failing because of flake8 checks for some lines I did not even touch but with, 
`flake8 --ignore=E501,E731,E402,E704,W503,W504,W605 daguerre` everything goes well, do you want me to update travis ci yml file?