### PR TITLE
Made {% adjust %} template tag return an info dict instead of a helper instance

### DIFF
--- a/daguerre/templatetags/daguerre.py
+++ b/daguerre/templatetags/daguerre.py
@@ -36,10 +36,13 @@ class AdjustmentNode(template.Node):
                     context[self.asvar] = AdjustmentInfoDict()
                 return ''
 
+        # Since this is used for a single image, we just need the info dict
+        # for the first image in the helper.
+        info_dict = adjusted[0][1]
         if self.asvar is not None:
-            context[self.asvar] = adjusted
+            context[self.asvar] = info_dict
             return ''
-        return escape(adjusted)
+        return escape(info_dict)
 
 
 class BulkAdjustmentNode(template.Node):

--- a/daguerre/tests/functional/test_templatetags.py
+++ b/daguerre/tests/functional/test_templatetags.py
@@ -25,7 +25,7 @@ class AdjustTemplatetagTestCase(BaseTestCase):
         helper = AdjustmentHelper([storage_path], generate=False)
         helper.adjust('fit', width=50, height=50)
         t = Template("{% load daguerre %}{% adjust image 'fit' width=50 "
-                     "height=50 as adj %}{{ adj }}")
+                     "height=50 %}")
         c = Context({'image': adjusted.adjusted})
         self.assertEqual(t.render(c), escape(helper[0][1]['url']))
 
@@ -35,7 +35,7 @@ class AdjustTemplatetagTestCase(BaseTestCase):
         c = Context({'image': 23})
         self.assertEqual(t.render(c), '')
 
-    def test_multiple(self):
+    def test_multiple_adjustments(self):
         # Tag should allow multiple adjustments to be passed in.
         storage_path = self.create_image('100x100.png')
         helper = AdjustmentHelper([storage_path])
@@ -45,6 +45,36 @@ class AdjustTemplatetagTestCase(BaseTestCase):
                      "height=50 'fit' width=25 %}")
         c = Context({'image': storage_path})
         self.assertEqual(t.render(c), escape(helper[0][1]['url']))
+
+    def test_using_as_renders_as_url(self):
+        # Tag should accept a path as its argument.
+        storage_path = self.create_image('100x100.png')
+        helper = AdjustmentHelper([storage_path], generate=False)
+        helper.adjust('fit', width=50, height=50)
+        t = Template("{% load daguerre %}{% adjust image 'fit' width=50 "
+                     "height=50 as asvar %}{{ asvar }}")
+        c = Context({'image': storage_path})
+        self.assertEqual(t.render(c), escape(helper[0][1]['url']))
+
+    def test_using_as_allows_width_access(self):
+        # Tag should accept a path as its argument.
+        storage_path = self.create_image('50x100_crop.png')
+        helper = AdjustmentHelper([storage_path], generate=False)
+        helper.adjust('fit', width=50, height=50)
+        t = Template("{% load daguerre %}{% adjust image 'fit' height=50 "
+                     "as asvar %}{{ asvar.width }}")
+        c = Context({'image': storage_path})
+        self.assertEqual(t.render(c), '25')
+
+    def test_using_as_allows_height_access(self):
+        # Tag should accept a path as its argument.
+        storage_path = self.create_image('50x100_crop.png')
+        helper = AdjustmentHelper([storage_path], generate=False)
+        helper.adjust('fit', width=50, height=50)
+        t = Template("{% load daguerre %}{% adjust image 'fit' width=25 "
+                     "as asvar %}{{ asvar.height }}")
+        c = Context({'image': storage_path})
+        self.assertEqual(t.render(c), '50')
 
 
 class BulkTestObject(object):


### PR DESCRIPTION
The {% adjust %} template tag was not supposed to return a helper instance; it's supposed to return the info dict for a single image adjustment. At some point that got a little messed up, probably as part of the work to introduce bulk adjustments and refactor how helpers worked?

In any case, this PR resolves the issue by updating the template tag to correctly return an info dict. This fixes #105. Thanks @pembeci for the report!