### PR TITLE
Issue 124 remove py2 shims

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,6 @@ Requirements
 * Python 3.5+
 * Pillow
 * Django 1.8 – 2.2
-* Six 1.10.0+
 
 Daguerre *may* work with earlier or later versions of these packages, but they are not officially supported.
 

--- a/daguerre/adjustments.py
+++ b/daguerre/adjustments.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from six.moves import xrange
-
 from daguerre.utils import exif_aware_resize, exif_aware_size
 
 try:
@@ -179,8 +176,8 @@ class Crop(Adjustment):
             min_penalty = None
             optimal_coords = None
 
-            for x in xrange(image_width - new_width + 1):
-                for y in xrange(image_height - new_height + 1):
+            for x in range(image_width - new_width + 1):
+                for y in range(image_height - new_height + 1):
                     penalty = 0
                     for area in areas:
                         penalty += self._get_penalty(area, x, y,

--- a/daguerre/management/commands/_daguerre_clean.py
+++ b/daguerre/management/commands/_daguerre_clean.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import os
 
 from django.conf import settings
@@ -6,7 +5,6 @@ from django.core.files.storage import default_storage
 from django.core.management.base import BaseCommand
 from django.db import models
 from django.template.defaultfilters import pluralize
-import six
 
 from daguerre.helpers import IOERRORS
 from daguerre.models import AdjustedImage, Area, DEFAULT_ADJUSTED_IMAGE_PATH
@@ -20,10 +18,10 @@ class Command(BaseCommand):
             reason_plural=None):
         count = queryset.count()
         if count == 1:
-            name = six.text_type(queryset.model._meta.verbose_name)
+            name = str(queryset.model._meta.verbose_name)
             reason = reason
         else:
-            name = six.text_type(queryset.model._meta.verbose_name_plural)
+            name = str(queryset.model._meta.verbose_name_plural)
             reason = reason_plural or reason
         if count == 0:
             self.stdout.write(u"No {0} {1}.\n".format(name, reason))

--- a/daguerre/management/commands/_daguerre_preadjust.py
+++ b/daguerre/management/commands/_daguerre_preadjust.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from optparse import make_option
 
 from django.apps import apps
@@ -8,7 +6,6 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db.models import Model
 from django.db.models.query import QuerySet
 from django.template.defaultfilters import pluralize
-import six
 
 from daguerre.models import AdjustedImage
 from daguerre.helpers import AdjustmentHelper, IOERRORS
@@ -69,10 +66,10 @@ class Command(BaseCommand):
             self._helpers = []
             try:
                 for (model_or_iterable, adjustments, lookup) in dp:
-                    if isinstance(model_or_iterable, six.string_types):
+                    if isinstance(model_or_iterable, (str, bytes)):
                         app_label, model_name = model_or_iterable.split('.')
                         model_or_iterable = apps.get_model(app_label, model_name)
-                    if (isinstance(model_or_iterable, six.class_types) and
+                    if (isinstance(model_or_iterable, type) and
                             issubclass(model_or_iterable, Model)):
                         iterable = model_or_iterable.objects.all()
                     elif isinstance(model_or_iterable, QuerySet):
@@ -96,9 +93,9 @@ class Command(BaseCommand):
         remaining_count = 0
         helpers = self._get_helpers()
         for helper in helpers:
-            empty_count += len([info_dict for info_dict in six.itervalues(helper.adjusted)
+            empty_count += len([info_dict for info_dict in helper.adjusted.values()
                                 if not info_dict])
-            skipped_count += len([info_dict for info_dict in six.itervalues(helper.adjusted)
+            skipped_count += len([info_dict for info_dict in helper.adjusted.values()
                                   if info_dict and 'ajax_url' not in info_dict])
             remaining_count += len(helper.adjusted) - skipped_count - empty_count
 
@@ -124,7 +121,7 @@ class Command(BaseCommand):
             failed_count = 0
             for helper in helpers:
                 remaining = {}
-                for item, info_dict in six.iteritems(helper.adjusted):
+                for item, info_dict in helper.adjusted.items():
                     # Skip if missing
                     if not info_dict:
                         continue
@@ -134,7 +131,7 @@ class Command(BaseCommand):
 
                     remaining.setdefault(helper.lookup_func(item, None), []).append(item)
 
-                for path, items in six.iteritems(remaining):
+                for path, items in remaining.items():
                     try:
                         helper._generate(path)
                     except IOERRORS:

--- a/daguerre/migrations/0002_auto_20140904_2006.py
+++ b/daguerre/migrations/0002_auto_20140904_2006.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models, migrations
 
 

--- a/daguerre/migrations/0003_auto_20160301_2342.py
+++ b/daguerre/migrations/0003_auto_20160301_2342.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import migrations
 
 

--- a/daguerre/migrations/0004_hash_upload_to_dir.py
+++ b/daguerre/migrations/0004_hash_upload_to_dir.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import migrations, models
 import daguerre.models
 

--- a/daguerre/models.py
+++ b/daguerre/models.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import hashlib
 import operator
 import warnings
 from datetime import datetime
+from functools import reduce
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -14,7 +13,6 @@ from django.db import models
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.utils.encoding import force_bytes, python_2_unicode_compatible
-from six.moves import reduce
 
 from daguerre.adjustments import registry
 

--- a/daguerre/utils.py
+++ b/daguerre/utils.py
@@ -7,7 +7,6 @@ from django.core.files.base import File
 from django.core.files.storage import default_storage
 from django.core.files.temp import NamedTemporaryFile
 from django.utils.encoding import smart_bytes
-import six
 try:
     from PIL import Image, ImageFile, ExifTags
 except ImportError:
@@ -33,7 +32,7 @@ ORIENTATION_TO_TRANSPOSE = {
 #: Which Exif orientation tags correspond to a 90deg or 270deg rotation.
 ROTATION_TAGS = (5, 6, 7, 8)
 #: Map human-readable Exif tag names to their markers.
-EXIF_TAGS = dict((y, x) for (x, y) in six.iteritems(ExifTags.TAGS))
+EXIF_TAGS = {y: x for x, y in ExifTags.TAGS.items()}
 
 
 def make_hash(*args, **kwargs):
@@ -41,7 +40,7 @@ def make_hash(*args, **kwargs):
     stop = kwargs.get('stop', None)
     step = kwargs.get('step', None)
     return sha1(smart_bytes(u''.join([
-        six.text_type(arg) for arg in args])
+        str(arg) for arg in args])
     )).hexdigest()[start:stop:step]
 
 

--- a/daguerre/views.py
+++ b/daguerre/views.py
@@ -5,7 +5,6 @@ from django.core.exceptions import ValidationError
 from django.http import (HttpResponse, Http404, HttpResponseRedirect,
                          HttpResponseForbidden)
 from django.views.generic import View
-import six
 
 from daguerre.helpers import AdjustmentHelper
 from daguerre.models import Area
@@ -29,7 +28,7 @@ class AdjustedImageRedirectView(View):
                 secure=self.secure,
                 generate=generate)
         except ValueError as e:
-            raise Http404(six.text_type(e))
+            raise Http404(str(e))
 
     def get(self, request, *args, **kwargs):
         helper = self.get_helper(generate=True)
@@ -121,7 +120,7 @@ class AjaxUpdateAreaView(View):
                 return HttpResponseForbidden('')
             area = Area(storage_path=storage_path, **data)
         else:
-            for fname, value in six.iteritems(data):
+            for fname, value in data.items():
                 setattr(area, fname, value)
 
         status = 200

--- a/docs/guides/installation-and-setup.rst
+++ b/docs/guides/installation-and-setup.rst
@@ -46,7 +46,6 @@ Versions and Requirements
 * Python 3.5+
 * Pillow
 * Django 1.8 – 2.2
-* Six 1.10.0+
 
 Daguerre *may* work with earlier versions of these packages, but they
 are not officially supported.

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     install_requires=[
         'Pillow',
         'django>=1.7',
-        'six>=1.10.0',
     ],
     extras_require={
         'docs': ["sphinx-rtd-theme>=0.1.5"],

--- a/test_project/requirements.txt
+++ b/test_project/requirements.txt
@@ -2,7 +2,7 @@
 Pillow==6.2.2
 mock==3.0.5
 pbr==5.4.4
-six==1.14.0
 
 # sub-dependencies
 funcsigs==1.0.2
+six==1.14.0


### PR DESCRIPTION
Resolved #124  - removed `six` and `__future__` usage in favor of the py3 equivalents