### PR TITLE
Issue 126 drop old django support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,6 @@ python:
   - "3.6"
   - "3.7"
 env:
-  - DB=sqlite3 DJANGO=1.8
-  - DB=mysql DJANGO=1.8
-  - DB=postgres DJANGO=1.8
-  - DB=sqlite3 DJANGO=1.9
-  - DB=mysql DJANGO=1.9
-  - DB=postgres DJANGO=1.9
-  - DB=sqlite3 DJANGO=1.10
-  - DB=mysql DJANGO=1.10
-  - DB=postgres DJANGO=1.10
   - DB=sqlite3 DJANGO=1.11
   - DB=mysql DJANGO=1.11
   - DB=postgres DJANGO=1.11

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Requirements
 
 * Python 3.5+
 * Pillow
-* Django 1.8 – 2.2
+* Django 1.11 – 2.2
 
 Daguerre *may* work with earlier or later versions of these packages, but they are not officially supported.
 

--- a/daguerre/helpers.py
+++ b/daguerre/helpers.py
@@ -9,11 +9,7 @@ from django.core.files.base import File
 from django.core.files.storage import default_storage
 from django.http import QueryDict
 from django.template import Variable, VariableDoesNotExist, TemplateSyntaxError
-try:
-    from django.urls import reverse
-except ImportError:
-    # Compatibility for Django < 1.10
-    from django.core.urlresolvers import reverse
+from django.urls import reverse
 try:
     from PIL import Image
 except ImportError:

--- a/daguerre/management/commands/daguerre.py
+++ b/daguerre/management/commands/daguerre.py
@@ -1,11 +1,7 @@
 import os
 import sys
 
-try:
-    from django.apps import apps
-except ImportError:
-    apps = None
-    from django.core.management import find_management_module
+from django.apps import apps
 from django.core.management import load_command_class
 from django.core.management.base import BaseCommand
 from django.utils.encoding import smart_str
@@ -18,12 +14,8 @@ NO_ARGS = """The daguerre management command requires a subcommand.
 
 class Command(BaseCommand):
     def _find_commands(self):
-        if apps:
-            parts = (apps.get_app_config('daguerre').path,
-                     'management', 'commands')
-        else:
-            parts = (find_management_module('daguerre'),
-                     'commands')
+        parts = (apps.get_app_config('daguerre').path,
+                 'management', 'commands')
         command_dir = os.path.join(*parts)
         try:
             return dict((f[10:-3], f[:-3]) for f in os.listdir(command_dir)

--- a/daguerre/widgets.py
+++ b/daguerre/widgets.py
@@ -1,10 +1,6 @@
 from django.contrib.admin.widgets import AdminFileWidget
 from django.utils.safestring import mark_safe
-try:
-    from django.urls import reverse
-except ImportError:
-    # Compatibility for Django < 1.10
-    from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 
 class AreaWidget(AdminFileWidget):

--- a/docs/guides/installation-and-setup.rst
+++ b/docs/guides/installation-and-setup.rst
@@ -45,7 +45,7 @@ Versions and Requirements
 
 * Python 3.5+
 * Pillow
-* Django 1.8 – 2.2
+* Django 1.11 – 2.2
 
 Daguerre *may* work with earlier versions of these packages, but they
 are not officially supported.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'Pillow',
-        'django>=1.7',
+        'django>=1.11',
     ],
     extras_require={
         'docs': ["sphinx-rtd-theme>=0.1.5"],

--- a/test_project/requirements-1.10.txt
+++ b/test_project/requirements-1.10.txt
@@ -1,2 +1,0 @@
-Django==1.10.8
--r requirements.txt

--- a/test_project/requirements-1.8.txt
+++ b/test_project/requirements-1.8.txt
@@ -1,2 +1,0 @@
-Django==1.8.19
--r requirements.txt

--- a/test_project/requirements-1.9.txt
+++ b/test_project/requirements-1.9.txt
@@ -1,2 +1,0 @@
-Django==1.9.13
--r requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,5 @@
 [tox]
 envlist =
-    py35-django18,
-    py36-django18,
-    py37-django18,
-    py35-django19,
-    py36-django19,
-    py37-django19,
-    py35-django110,
-    py36-django110,
-    py37-django110,
     py35-django111,
     py36-django111,
     py37-django111,
@@ -26,60 +17,6 @@ envlist =
 changedir = {toxinidir}/test_project
 commands =
     {envpython} manage.py test --verbosity=2 {posargs:daguerre}
-
-[testenv:py35-django18]
-basepython=python3.5
-deps =
-    --no-deps
-    -r{toxinidir}/test_project/requirements-1.8.txt
-
-[testenv:py36-django18]
-basepython=python3.6
-deps =
-    --no-deps
-    -r{toxinidir}/test_project/requirements-1.8.txt
-
-[testenv:py37-django18]
-basepython=python3.7
-deps =
-    --no-deps
-    -r{toxinidir}/test_project/requirements-1.8.txt
-
-[testenv:py35-django19]
-basepython=python3.5
-deps =
-    --no-deps
-    -r{toxinidir}/test_project/requirements-1.9.txt
-
-[testenv:py36-django19]
-basepython=python3.6
-deps =
-    --no-deps
-    -r{toxinidir}/test_project/requirements-1.9.txt
-
-[testenv:py37-django19]
-basepython=python3.7
-deps =
-    --no-deps
-    -r{toxinidir}/test_project/requirements-1.9.txt
-
-[testenv:py35-django110]
-basepython=python3.5
-deps =
-    --no-deps
-    -r{toxinidir}/test_project/requirements-1.10.txt
-
-[testenv:py36-django110]
-basepython=python3.6
-deps =
-    --no-deps
-    -r{toxinidir}/test_project/requirements-1.10.txt
-
-[testenv:py37-django110]
-basepython=python3.7
-deps =
-    --no-deps
-    -r{toxinidir}/test_project/requirements-1.10.txt
 
 [testenv:py35-django111]
 basepython=python3.5


### PR DESCRIPTION
Resolved #126. Dropped official support for versions of django older than 1.11.